### PR TITLE
MODSENDER-28 update RMB and vertx versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>29.0.1</raml-module-builder.version>
-    <vertx.version>3.8.1</vertx.version>
+    <raml-module-builder.version>30.0.2</raml-module-builder.version>
+    <vertx.version>3.9.1</vertx.version>
     <junit.version>4.12</junit.version>
     <rest-assured.version>3.1.1</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,9 +1,14 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.*;
-import io.vertx.ext.web.client.WebClient;
 import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.sender.DeliveryVerticle;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 
 
 public class InitAPIs implements InitAPI {
@@ -12,6 +17,6 @@ public class InitAPIs implements InitAPI {
     context.put("webClient", WebClient.create(vertx));
     Promise<String> promise = Promise.promise();
     vertx.deployVerticle(new DeliveryVerticle(), promise);
-    promise.future().map(true).setHandler(resultHandler);
+    promise.future().map(true).onComplete(resultHandler);
   }
 }

--- a/src/main/java/org/folio/rest/impl/MessageDeliveryImpl.java
+++ b/src/main/java/org/folio/rest/impl/MessageDeliveryImpl.java
@@ -1,10 +1,9 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang.StringUtils;
 import org.folio.rest.jaxrs.model.Notification;
 import org.folio.rest.jaxrs.resource.MessageDelivery;
@@ -14,8 +13,11 @@ import org.folio.sender.SenderService;
 import org.folio.sender.SenderServiceImpl;
 import org.folio.sender.util.ExceptionHelper;
 
-import javax.ws.rs.core.Response;
-import java.util.Map;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 
 public class MessageDeliveryImpl implements MessageDelivery {
 
@@ -39,7 +41,7 @@ public class MessageDeliveryImpl implements MessageDelivery {
         .map(PostMessageDeliveryResponse.respond204WithTextPlain(StringUtils.EMPTY))
         .map(Response.class::cast)
         .otherwise(ExceptionHelper::handleException)
-        .setHandler(asyncResultHandler);
+        .onComplete(asyncResultHandler);
     } catch (Exception e) {
       asyncResultHandler.handle(Future.succeededFuture(
         ExceptionHelper.handleException(e)));


### PR DESCRIPTION
## Approach

- Update to RMB v30.0.2
- Update vertx to 3.9.1
- Do all related changes according to RMB upgrading notes

Resolves: [MODSENDER-28](https://issues.folio.org/browse/MODSENDER-28)