### PR TITLE
[MODSENDER-33] Allow additional properties in user schema

### DIFF
--- a/ramls/userdata.json
+++ b/ramls/userdata.json
@@ -124,7 +124,7 @@
                 "type": "boolean"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "preferredContactTypeId": {
@@ -132,7 +132,7 @@
           "type": "string"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "required": [
         "lastName"
       ]
@@ -171,5 +171,5 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/src/test/java/org/folio/rest/MessageDeliveryTest.java
+++ b/src/test/java/org/folio/rest/MessageDeliveryTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.Address;
 import org.folio.rest.jaxrs.model.CustomFields;
 import org.folio.rest.jaxrs.model.Message;
 import org.folio.rest.jaxrs.model.Notification;
@@ -32,6 +33,7 @@ import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.MediaType;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 
 @RunWith(VertxUnitRunner.class)
@@ -119,8 +121,51 @@ public class MessageDeliveryTest {
   public void shouldReturnNoContentAndSendEmailWhenRequestIsValid() {
     User mockRecipient = new User()
       .withId(UUID.randomUUID().toString())
-      .withPersonal(new Personal().withEmail("test@test.com"))
-      .withCustomFields(new CustomFields().withAdditionalProperty("Custom field", "value"));
+      .withPersonal(new Personal().withEmail("test@test.com"));
+
+    mockUserModule(mockRecipient.getId(), mockRecipient);
+    mockEmailModule();
+
+    Message emailChannel1 = new Message()
+      .withDeliveryChannel("email")
+      .withHeader("header1")
+      .withBody("body1")
+      .withOutputFormat(MediaType.TEXT_PLAIN);
+    Message emailChannel2 = new Message()
+      .withDeliveryChannel("email")
+      .withHeader("header2")
+      .withBody("body2")
+      .withOutputFormat(MediaType.TEXT_HTML);
+
+    Notification notification = new Notification()
+      .withNotificationId(UUID.randomUUID().toString())
+      .withRecipientUserId(mockRecipient.getId())
+      .withMessages(Arrays.asList(emailChannel1, emailChannel2));
+
+    RestAssured.given()
+      .spec(spec)
+      .header(mockUrlHeader)
+      .body(toJson(notification))
+      .when()
+      .post(MESSAGE_DELIVERY_PATH)
+      .then()
+      .statusCode(HttpStatus.SC_NO_CONTENT);
+
+    WireMock.verify(1, WireMock.getRequestedFor(
+      WireMock.urlMatching("/users/" + mockRecipient.getId())));
+  }
+
+  @Test
+  public void shouldNotFailWhenUserContainsAdditionalProperties() {
+    User mockRecipient = new User()
+      .withId(UUID.randomUUID().toString())
+      .withCustomFields(new CustomFields().withAdditionalProperty("customField", "value"))
+      .withAdditionalProperty("additionalProperty", "value")
+      .withPersonal(new Personal()
+        .withEmail("test@test.com")
+        .withAdditionalProperty("additionalProperty", "value")
+        .withAddresses(Collections.singletonList(
+          new Address().withAdditionalProperty("additionalProperty", "value"))));
 
     mockUserModule(mockRecipient.getId(), mockRecipient);
     mockEmailModule();


### PR DESCRIPTION
JSON schemas pulled from other modules should always have `"additionalProperties": true` for all objects. Otherwise adding a field to the entity by other modules becomes a breaking change.

Resolves [MODSENDER-33](https://issues.folio.org/browse/MODSENDER-33).