### PR TITLE
MODSENDER-44 Upgrade RMB to v33.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <vertx.version>4.1.0.CR1</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>


### PR DESCRIPTION
Update Log4j to a newer version with CVE-2021-44228 vulnerability fixed.