### PR TITLE
MODSENDER-47 Update RMB to v33.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   </licenses>
 
   <properties>
-    <raml-module-builder.version>33.0.4</raml-module-builder.version>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
+    <vertx.version>4.2.4</vertx.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -88,16 +88,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Purpose
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to update RMB
### Approach
•	Updated RMB version
•	Updated Vertx version
•	Removed FOLIO fork of the vertx-sql-client and vertx-pg-client
### Learning
https://issues.folio.org/browse/MODSENDER-47
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md