### PR TITLE
MODSENDER-69 - Permission name changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ complexity, sending queues, persistence of messages, available sending channels 
 REST endpoint - POST /message-delivery for delivering message by using available delivery channels.
 
 **POST /message-delivery**  
-**Required permission:** "sender.message-delivery"
+**Required permission:** "sender.message-delivery.post"
 
 Request body example:
 ```

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -23,7 +23,7 @@
         {
           "methods": ["POST"],
           "pathPattern": "/message-delivery",
-          "permissionsRequired": ["sender.message-delivery"],
+          "permissionsRequired": ["sender.message-delivery.post"],
           "modulePermissions": ["email.message.post", "batch-print.entries.mail.post", "users.item.get" ]
         }
       ]
@@ -31,9 +31,10 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "sender.message-delivery",
+      "permissionName": "sender.message-delivery.post",
       "displayName": "Message delivery",
-      "description": "Send message"
+      "description": "Send message",
+      "replaces": ["sender.message-delivery"]
     }
   ],
   "launchDescriptor": {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -18,7 +18,7 @@
   "provides": [
     {
       "id": "message-delivery",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <rest-assured.version>5.4.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
   </properties>
 
   <dependencyManagement>
@@ -341,7 +342,18 @@
           <localCheckout>true</localCheckout>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request._
To cater to https://folio-org.atlassian.net/browse/MODSENDER-69

## Approach
_How does this change fulfill the purpose?_
Renamed the permission and added replaces section.
Other effected folio code base PR's will be created to update the permission name in the respective MD files.

https://github.com/folio-org/folio-integration-tests/pull/1551
https://github.com/folio-org/mod-notify/pull/137
https://github.com/folio-org/mod-roles-keycloak/pull/160


### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
