### PR TITLE
MODSENDER-79: Incorrect interface version required in master branch

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,7 @@
     },
     {
       "id" : "batch-print",
-      "version" : "1.1"
+      "version" : "1.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
[MODSENDER-79:Incorrect interface version required in master branch](https://folio-org.atlassian.net/browse/MODSENDER-79)

