### PR TITLE
MODSENDER-78: Upgrade module to Vert.x 5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2026-XX-XX v1.15.0-SNAPSHOT
+* Upgrade module to Vert.x 5.0 ([MODSENDER-78](https://folio-org.atlassian.net/browse/MODSENDER-78))
+
 ## 2025-03-14 v1.2.0
 * Update mod-sender to Java 21([FOLIO-4215](https://folio-org.atlassian.net/browse/FOLIO-4215))
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,31 @@
 
   <properties>
     <java.version>21</java.version>
-    <aspectj.version>1.9.22.1</aspectj.version>
-    <raml-module-builder.version>35.4.0</raml-module-builder.version>
-    <vertx.version>4.5.13</vertx.version>
-    <junit.version>4.13.1</junit.version>
-    <rest-assured.version>5.5.0</rest-assured.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Dependency versions -->
+    <raml-module-builder.version>36.0.0-SNAPSHOT</raml-module-builder.version>
+    <vertx.version>5.0.6</vertx.version>
+    <log4j.version>2.25.2</log4j.version>
+
+    <!-- Test dependency versions -->
+    <aspectj.version>1.9.25.1</aspectj.version>
+    <junit.version>4.13.1</junit.version>
+    <rest-assured.version>6.0.0</rest-assured.version>
+    <wiremock.version>3.12.1</wiremock.version>
+
+    <!-- Plugin versions -->
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
+    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+    <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <aspectj-maven-plugin.version>1.14.1</aspectj-maven-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -30,7 +47,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.0</version>
+        <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,18 +100,13 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
-      <version>3.12.1</version>
+      <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>
       <artifactId>jopt-simple</artifactId>
       <version>5.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
     </dependency>
   </dependencies>
 
@@ -110,7 +122,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
@@ -118,7 +130,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <release>${java.version}</release>
           <encoding>UTF-8</encoding>
@@ -132,7 +144,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${build-helper-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>add_generated_sources_folder</id>
@@ -166,7 +178,7 @@
       <plugin>
         <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.14</version>
+        <version>${aspectj-maven-plugin.version}</version>
         <configuration>
           <verbose>true</verbose>
           <release>${java.version}</release>
@@ -208,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>${maven-resources-plugin.version}</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -249,7 +261,7 @@
       <plugin>
         <groupId>com.coderplus.maven.plugins</groupId>
         <artifactId>copy-rename-maven-plugin</artifactId>
-        <version>1.0</version>
+        <version>${copy-rename-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>rename-descriptor-outputs</id>
@@ -276,7 +288,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <!-- Replace the baseUri in the RAMLs that have been copied to
@@ -299,7 +311,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -323,6 +335,7 @@
                     <Multi-Release>true</Multi-Release>
                   </manifestEntries>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
@@ -334,7 +347,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>${maven-release-plugin.version}</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>

--- a/src/main/java/org/folio/rest/impl/InitAPIs.java
+++ b/src/main/java/org/folio/rest/impl/InitAPIs.java
@@ -1,22 +1,26 @@
 package org.folio.rest.impl;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.resource.interfaces.InitAPI;
 import org.folio.sender.DeliveryVerticle;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
 
 public class InitAPIs implements InitAPI {
 
+  private static final Logger LOG = LogManager.getLogger(InitAPIs.class);
+
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
     context.put("webClient", WebClient.create(vertx));
-    Promise<String> promise = Promise.promise();
-    vertx.deployVerticle(new DeliveryVerticle(), promise);
-    promise.future().map(true).onComplete(resultHandler);
+    vertx.deployVerticle(new DeliveryVerticle())
+      .map(true)
+      .onFailure(err -> LOG.error("Failed to deploy DeliveryVerticle", err))
+      .onComplete(resultHandler);
   }
 }

--- a/src/main/java/org/folio/sender/SenderServiceImpl.java
+++ b/src/main/java/org/folio/sender/SenderServiceImpl.java
@@ -1,16 +1,14 @@
 package org.folio.sender;
 
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
-import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.Message;
 import org.folio.rest.jaxrs.model.Notification;
 import org.folio.rest.jaxrs.model.User;
@@ -68,18 +66,14 @@ public class SenderServiceImpl implements SenderService {
     okapiHeaders.fillRequestHeaders(request.headers());
     request.putHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
 
-    Promise<HttpResponse<Buffer>> promise = Promise.promise();
-    request.send(promise);
-    return promise.future().map(response -> {
-      switch (response.statusCode()) {
-        case HttpStatus.SC_OK:
-          return response.bodyAsJson(User.class);
-        case HttpStatus.SC_NOT_FOUND:
-          throw new BadRequestException(response.bodyAsString());
-        default:
-          throw new InternalServerErrorException();
-      }
-    });
+    return request.send()
+      .map(response ->
+        switch (response.statusCode()) {
+          case HttpStatus.SC_OK -> response.bodyAsJson(User.class);
+          case HttpStatus.SC_NOT_FOUND -> throw new BadRequestException(response.bodyAsString());
+          default -> throw new InternalServerErrorException();
+        }
+    );
   }
 }
 

--- a/src/main/java/org/folio/sender/delivery/EmailDeliveryChannel.java
+++ b/src/main/java/org/folio/sender/delivery/EmailDeliveryChannel.java
@@ -5,9 +5,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.EmailEntity;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.model.OkapiHeaders;
@@ -39,15 +39,15 @@ public class EmailDeliveryChannel implements DeliveryChannel {
 
         HttpRequest<Buffer> request = createRequestAndPrepareHeaders(okapiHeadersJson, emailUrlPath, webClient);
 
-        request.sendJson(emailEntity, response -> {
-        if (response.failed()) {
-          LOG.error("deliverMessage:: Error from Email module {} ", response.cause().getMessage());
-        } else if (response.result().statusCode() != HttpStatus.SC_OK) {
-          String errorMessage = String.format("deliverMessage:: Email module responded with status '%s' and body '%s'",
-            response.result().statusCode(), response.result().bodyAsString());
-          LOG.error(errorMessage);
-        }
-      });
+        request.sendJson(emailEntity)
+          .onFailure(error -> LOG.error("deliverMessage:: Error from Email module {} ", error.getMessage()))
+          .onSuccess(response -> {
+            if (response.statusCode() != HttpStatus.SC_OK) {
+              String errorMessage = String.format("deliverMessage:: Email module responded with status '%s' and body '%s'",
+                response.statusCode(), response.bodyAsString());
+              LOG.error(errorMessage);
+            }
+          });
     } catch (Exception e) {
       LOG.error("deliverMessage:: Error while attempting to deliver message to recipient {} ", recipientJson, e);
     }

--- a/src/main/java/org/folio/sender/delivery/MailDeliveryChannel.java
+++ b/src/main/java/org/folio/sender/delivery/MailDeliveryChannel.java
@@ -5,9 +5,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.EmailEntity;
 import org.folio.rest.jaxrs.model.User;
 
@@ -37,16 +37,16 @@ public class MailDeliveryChannel implements DeliveryChannel {
       HttpRequest<Buffer> request = EmailDeliveryChannel.createRequestAndPrepareHeaders(
           okapiHeadersJson, mailUrlPath, webClient);
 
-      request.sendJson(emailEntity, response -> {
-        if (response.failed()) {
-          LOG.error("deliverMessage:: Error from Mail module {} ", response.cause().getMessage());
-        } else if (response.result().statusCode() != HttpStatus.SC_OK) {
-          String errorMessage = String.format("deliverMessage:: Mail module responded with "
-              + "status '%s' and body '%s'",
-              response.result().statusCode(), response.result().bodyAsString());
-          LOG.error(errorMessage);
-        }
-      });
+      request.sendJson(emailEntity)
+        .onFailure(error -> LOG.error("deliverMessage:: Error from Mail module {} ", error.getMessage()))
+        .onSuccess(response -> {
+          if (response.statusCode() != HttpStatus.SC_OK) {
+            String errorMessage = String.format("deliverMessage:: Mail module responded with "
+                + "status '%s' and body '%s'",
+              response.statusCode(), response.bodyAsString());
+            LOG.error(errorMessage);
+          }
+        });
     } catch (Exception e) {
       LOG.error("deliverMessage:: Error while attempting to "
           + "deliver message to recipient {} ", recipientJson, e);

--- a/src/main/java/org/folio/sender/util/ExceptionHelper.java
+++ b/src/main/java/org/folio/sender/util/ExceptionHelper.java
@@ -1,9 +1,8 @@
 package org.folio.sender.util;
 
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.folio.HttpStatus;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -18,19 +18,19 @@ appender.console.layout.stacktraceAsString = true
 
 appender.console.layout.requestId.type = KeyValuePair
 appender.console.layout.requestId.key = requestId
-appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
+appender.console.layout.requestId.value = $${FolioLoggingContext:requestId}
 
 appender.console.layout.tenantId.type = KeyValuePair
 appender.console.layout.tenantId.key = tenantId
-appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
+appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantId}
 
 appender.console.layout.userId.type = KeyValuePair
 appender.console.layout.userId.key = userId
-appender.console.layout.userId.value = $${FolioLoggingContext:userid}
+appender.console.layout.userId.value = $${FolioLoggingContext:userId}
 
 appender.console.layout.moduleId.type = KeyValuePair
 appender.console.layout.moduleId.key = moduleId
-appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
+appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleId}
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %.-10240m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %.-10240m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/src/test/java/org/folio/rest/MessageDeliveryTest.java
+++ b/src/test/java/org/folio/rest/MessageDeliveryTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.http.HttpStatus;
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.Address;
 import org.folio.rest.jaxrs.model.CustomFields;
 import org.folio.rest.jaxrs.model.Message;
@@ -60,7 +60,8 @@ public class MessageDeliveryTest {
     port = NetworkUtils.nextFreePort();
     DeploymentOptions options = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", port));
-    vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess());
+    vertx.deployVerticle(RestVerticle.class.getName(), options)
+      .onComplete(context.asyncAssertSuccess());
 
     spec = new RequestSpecBuilder()
       .setContentType(ContentType.JSON)
@@ -70,13 +71,13 @@ public class MessageDeliveryTest {
   }
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     mockUrlHeader = new Header(OkapiHeaders.OKAPI_URL, "http://localhost:" + mockServer.port());
   }
 
   @AfterClass
   public static void tearDown(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+    vertx.close().onComplete(context.asyncAssertSuccess());
   }
 
   @Test
@@ -88,7 +89,7 @@ public class MessageDeliveryTest {
       .when()
       .post(MESSAGE_DELIVERY_PATH)
       .then()
-      .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+      .statusCode(HttpStatus.SC_UNPROCESSABLE_CONTENT);
   }
 
   @Test

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %.-10240m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestId}] [$${FolioLoggingContext:tenantId}] [$${FolioLoggingContext:userId}] [$${FolioLoggingContext:moduleId}] %-5p %-20.20C{1} %.-10240m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Purpose
Upgrade module to Vert.x 5.0. Also update RMB dependency to the corresponding version.

## Approach
- update Vert.x version to 5.0
- update RAML dependency to 36.0.0-SNAPSHOT
- make necessary adjustments in source code and tests as per migration instructions/guides

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODSENDER-78](https://folio-org.atlassian.net/browse/MODSENDER-78)
